### PR TITLE
Fix limit logic

### DIFF
--- a/openaleph_search/parse/parser.py
+++ b/openaleph_search/parse/parser.py
@@ -42,7 +42,10 @@ class QueryParser:
             parsed_limit = self.getint("limit", 20)
             limit = min(
                 max_limit or MAX_PAGE,
-                max(0, 20 if parsed_limit is None else parsed_limit),
+                max(
+                    0,
+                    20 if (parsed_limit is None or parsed_limit == 0) else parsed_limit,
+                ),
             )
         self.limit = limit
         self.next_limit = self.getint("next_limit", limit)


### PR DESCRIPTION
If the `QueryParser` received `args` where the limit is set (`ImmutableMultiDict([('limit', '0')`), then `parsed_limit` will evaluate to 0. Hence, in `__init__`, `limit` will evaluate to 0. 

In OpenAleph, this creates a bug where the `entities/<id>/expand` path never returns any results because the limit is always set to 0. 